### PR TITLE
Add isNotEmpty method to strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 1.0.0-dev.3
+   * Added isNotEmpty
+
 #### 1.0.0-dev.2
    * Added isDigit
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A set of string utilities for Dart.
 
 `isEmpty` checks if a string is `null` or empty.
 
+`isNotEmpty` checks if a string is not `null` and not empty.
+
 `equalsIgnoreCase` checks if two strings are equal, ignoring case.
 
 `compareIgnoreCase` compares two strings, ignoring case.

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -21,6 +21,9 @@ bool isBlank(String s) => s == null || s.trim().isEmpty;
 /// Returns `true` if [s] is null or empty.
 bool isEmpty(String s) => s == null || s.isEmpty;
 
+/// Returns `true` if [s] is a not empty string.
+bool isNotEmpty(String s) => s != null && s.isNotEmpty;
+
 /// Returns `true` if [rune] represents a digit.
 ///
 /// The definition of digit matches the Unicode `0x3?` range of Western European

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -21,7 +21,7 @@ bool isBlank(String s) => s == null || s.trim().isEmpty;
 /// Returns `true` if [s] is null or empty.
 bool isEmpty(String s) => s == null || s.isEmpty;
 
-/// Returns `true` if [s] is a not empty string.
+/// Returns `true` if [s] is a non-empty string.
 bool isNotEmpty(String s) => s != null && s.isNotEmpty;
 
 /// Returns `true` if [rune] represents a digit.

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -15,7 +15,7 @@
 library quiver.strings;
 
 import 'package:quiver_strings/strings.dart';
-import 'package:test/test.dart' hide isEmpty;
+import 'package:test/test.dart' hide isEmpty, isNotEmpty;
 
 main() {
   group('isBlank', () {
@@ -45,6 +45,21 @@ main() {
     });
     test('should consider non-whitespace string to be not empty', () {
       expect(isEmpty('hello'), isFalse);
+    });
+  });
+
+  group('isNotEmpty', () {
+    test('should consider null to be empty', () {
+      expect(isNotEmpty(null), isFalse);
+    });
+    test('should consider the empty string to be empty', () {
+      expect(isNotEmpty(''), isFalse);
+    });
+    test('should consider whitespace string to be not empty', () {
+      expect(isNotEmpty(' '), isTrue);
+    });
+    test('should consider non-whitespace string to be not empty', () {
+      expect(isNotEmpty('hello'), isTrue);
     });
   });
 


### PR DESCRIPTION
Dart convention is to provide both methods in most interfaces,
so it is better dart style to have:

```
if(isNotEmpty(nullableString))
```

than:

```
if(!isEmpty(nullableString))
```
