### PR TITLE
Update README: remove repeat function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ unchanged.
 `emptyToNull` turns empty string to `null`, and returns non-empty strings
 unchanged.
 
-`repeat` concatenates a string to itself a given number of times.
-
 `loop` allows you to loop through characters in a string starting and ending at
 arbitrary indices. Out of bounds indices allow you to wrap around the string,
 supporting a number of use-cases, including:


### PR DESCRIPTION
In bd2f96eef4e6d2b44af60acfaea56f4b602d92d6, repeat was removed from
this packages. Instead, users should use String's operator*. e.g.,

  String tomsDinerIntro = 'do ' * 16;